### PR TITLE
remove typescript

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -3,15 +3,13 @@ var ts = require('gulp-typescript');
 var merge = require('merge2');
 var notifier = require('node-notifier');
 var sourcemaps = require('gulp-sourcemaps');
-var typescript15 = require('typescript');
 
 var tsProjectEmily = ts.createProject({
     declarationFiles: true,
     noExternalResolve: false,
     module: 'commonjs',
     target: 'ES5',
-    noEmitOnError: false,
-    typescript: typescript15
+    noEmitOnError: false
 });
 
 gulp.task('ts', function() {


### PR DESCRIPTION
```
typescript15 = require('typescript');
```

typescript fehlt als dependency in der package.json und wird meiner meinung nach nicht benötigt, allerdings kracht jetzt gulp ts. Vielleicht wird es also doch benötigt. Schau mal bitte.
